### PR TITLE
python-cffi: mark BROKEN due to buildbot breakage

### DIFF
--- a/lang/python-cffi/Makefile
+++ b/lang/python-cffi/Makefile
@@ -33,7 +33,7 @@ define Package/python-cffi
 	SUBMENU:=Python
 	TITLE:=python-cffi
 	URL:=http://cffi.readthedocs.org/
-	DEPENDS:=+libffi +python-light +python-pycparser
+	DEPENDS:=+libffi +python-light +python-pycparser @BROKEN
 endef
 
 define Package/python-cffi/description


### PR DESCRIPTION
python-cffi's host section has trouble compiling at buildbot.
Yesterday it stopped all buildbot runs that reached the package.

Mark the package temporarily as BROKEN to enable buildbot to complete the build.

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
